### PR TITLE
Temporarily disabled duplication of Composite Node & Sub Graph

### DIFF
--- a/Source/JointEditor/Private/Node/JointEdGraphNode_Composite.cpp
+++ b/Source/JointEditor/Private/Node/JointEdGraphNode_Composite.cpp
@@ -185,7 +185,7 @@ void UJointEdGraphNode_Composite::AllocateDefaultPins()
 
 bool UJointEdGraphNode_Composite::CanDuplicateNode() const
 {
-	return true; //Take care the occasion when there is another output node with the same Guid.
+	return false;
 }
 
 void UJointEdGraphNode_Composite::ReconstructNode()
@@ -197,10 +197,10 @@ void UJointEdGraphNode_Composite::ReconstructNode()
 	NodeConnectionListChanged();
 }
 
-void UJointEdGraphNode_Composite::PostPlacedNewNode()
+void UJointEdGraphNode_Composite::CreateBoundGraphIfNeeded()
 {
-	UpdatePins();
-
+	if (BoundGraph) return; //already created.
+	
 	// Create a new graph
 	BoundGraph = UJointEdGraph::CreateNewJointGraph(GetGraph(), GetJointManager(), FName("SubGraph"));
 	BoundGraph->bAllowDeletion = false;
@@ -231,6 +231,13 @@ void UJointEdGraphNode_Composite::PostPlacedNewNode()
 
 	// Add the new graph as a child of our parent graph
 	GetGraph()->SubGraphs.Add(BoundGraph);
+}
+
+void UJointEdGraphNode_Composite::PostPlacedNewNode()
+{
+	UpdatePins();
+
+	CreateBoundGraphIfNeeded();
 
 	Super::PostPlacedNewNode();
 }
@@ -714,6 +721,32 @@ void UJointEdGraphNode_Composite::ModifyGraphNodeSlate()
 			]
 		];
 	}
+}
+
+void UJointEdGraphNode_Composite::PostPasteNode()
+{
+	if (BoundGraph)
+	{
+		//Duplicate the bound graph, and assign it to the new node.
+		UEdGraph* NewGraph = DuplicateObject<UEdGraph>(BoundGraph.Get(), GetGraph(), NAME_None);
+		NewGraph->SetFlags(RF_Transactional);
+
+		if (UJointEdGraph* NewJointEdGraph = Cast<UJointEdGraph>(NewGraph))
+		{
+			NewJointEdGraph->bAllowDeletion = false;
+			NewJointEdGraph->UpdateGraph();
+		}
+
+		BoundGraph = NewGraph;
+		
+		// Add the new graph as a child of our parent graph
+		GetGraph()->SubGraphs.Add(BoundGraph);
+	}else
+	{
+		CreateBoundGraphIfNeeded();
+	}
+	
+	Super::PostPasteNode();
 }
 
 

--- a/Source/JointEditor/Public/Node/JointEdGraphNode_Composite.h
+++ b/Source/JointEditor/Public/Node/JointEdGraphNode_Composite.h
@@ -69,7 +69,10 @@ public:
 	virtual void DestroyNode() override;
 	virtual void ModifyGraphNodeSlate() override;
 
+	virtual void PostPasteNode() override;
 public:
+
+	void CreateBoundGraphIfNeeded();
 
 	virtual bool CanHaveBreakpoint() const override;
 	virtual void GetNodeContextMenuActions(class UToolMenu* Menu, class UGraphNodeContextMenuContext* Context) const override;


### PR DESCRIPTION
Currently the editor doesn't handle this properly and it requires a significant amount of changes - we will take a look into this on 2.11.0