### PR TITLE
Joint 2.11.3

### DIFF
--- a/Joint.uplugin
+++ b/Joint.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 65,
-	"VersionName": "2.11.2",
+	"Version": 66,
+	"VersionName": "2.11.3",
 	"FriendlyName": "Joint",
 	"Description": "General Purpose Modular Playback Framework for Unreal Engine",
 	"Category": "Conversation",

--- a/Source/Joint/Public/JointActor.h
+++ b/Source/Joint/Public/JointActor.h
@@ -165,11 +165,11 @@ private:
 	/**
 	 * Cached Joint nodes for the replication.
 	 */
-	UPROPERTY(Transient, Replicated, ReplicatedUsing = OnRep_CachedAllNodesForNetworking)
-	TArray<TObjectPtr<UJointNodeBase>> CachedAllNodesForNetworking;
+	UPROPERTY(Transient, Replicated, ReplicatedUsing = OnRep_CachedNodesForNetworking)
+	TArray<TObjectPtr<UJointNodeBase>> CachedNodesForNetworking;
 
 	UFUNCTION()
-	void OnRep_CachedAllNodesForNetworking(const TArray<UJointNodeBase*>& PreviousCachedAllNodesForNetworking);
+	void OnRep_CachedNodesForNetworking(const TArray<UJointNodeBase*>& PreviousCachedNodesForNetworking);
 
 
 public:
@@ -367,12 +367,9 @@ public:
 
 	void EndManagerFragments();
 public:
+	
 	/**
 	 * Networking of the Joint instance actor.
-	 * Joint instance will replicate only following 3 properties by itself:
-	 * JointGuid, JointManager, PlayingJointNode.
-	 *
-	 * The most important one is the Playing Joint node. Instance doesn't replicate the begin play event of the other nodes, but it replicates the change on the base node and its play action.
 	 */
 
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;

--- a/Source/JointEditor/Private/Editor/Sequencer/JointMovieTrackEditor.cpp
+++ b/Source/JointEditor/Private/Editor/Sequencer/JointMovieTrackEditor.cpp
@@ -207,12 +207,13 @@ bool FJointMovieTrackEditor::SupportsSequence(UMovieSceneSequence* InSequence) c
 
 void FJointMovieTrackEditor::Tick(float DeltaTime)
 {
+	/*
 	TSharedPtr<ISequencer> SequencerPin = GetSequencer();
 	if (!SequencerPin.IsValid())
 	{
 		return;
 	}
-
+	
 	EMovieScenePlayerStatus::Type PlaybackState = SequencerPin->GetPlaybackStatus();
 
 	if (FSlateThrottleManager::Get().IsAllowingExpensiveTasks() && PlaybackState != EMovieScenePlayerStatus::Playing && PlaybackState != EMovieScenePlayerStatus::Scrubbing)
@@ -228,6 +229,7 @@ void FJointMovieTrackEditor::Tick(float DeltaTime)
 
 		SequencerPin->ExitSilentMode();
 	}
+	*/
 }
 
 const FSlateBrush* FJointMovieTrackEditor::GetIconBrush() const

--- a/Source/JointEditor/Private/Editor/Slate/GraphNode/SJointGraphPin.cpp
+++ b/Source/JointEditor/Private/Editor/Slate/GraphNode/SJointGraphPin.cpp
@@ -156,7 +156,7 @@ TSharedRef<SWidget> SJointGraphPinBase::GetLabelWidget(const FName& InLabelStyle
 	
 	return SAssignNew(TextBlock, STextBlock)
 		.RenderOpacity(ShouldAlwaysDisplayNameText() ? 0.6 : 0)
-		.Text(GetPinLabel())
+		.Text(GraphPinObj && GraphPinObj->GetOwningNode() && GraphPinObj->GetOwningNode()->GetSchema() ? GetPinLabel() : FText::GetEmpty())
 		.TextStyle(FJointEditorStyle::Get(), "JointUI.TextBlock.Black.h3")
 		.Visibility(bShowLabel ? EVisibility::HitTestInvisible : EVisibility::Collapsed)
 		.ColorAndOpacity(this, &SJointGraphPinBase::GetPinTextColor);

--- a/Source/JointEditor/Private/Editor/Toolkit/JointEditorToolkit.cpp
+++ b/Source/JointEditor/Private/Editor/Toolkit/JointEditorToolkit.cpp
@@ -2915,6 +2915,24 @@ void FJointEditorToolkit::CopySelectedNodes()
 		}
 	}
 	
+	// Remove the nodes that are contained within other selected nodes - we only want to copy the top-level nodes
+	for (int i = NodesToCopy.Num() - 1; i >= 0; --i)
+	{
+		UObject* NodeToCheck = NodesToCopy.Array()[i];
+
+		if (UJointEdGraphNode* CastedNode = Cast<UJointEdGraphNode>(NodeToCheck))
+		{
+			for (UJointEdGraphNode* SubNode : CastedNode->GetAllSubNodesInHierarchy())
+			{
+				if (NodesToCopy.Contains(SubNode))
+				{
+					NodesToCopy.Remove(SubNode);
+				}
+			}
+		}
+	}
+		
+	
 	for (UObject* NodeToCopy : NodesToCopy)
 	{
 		if (UEdGraphNode* CastedNode = Cast<UEdGraphNode>(NodeToCopy))
@@ -3095,6 +3113,17 @@ void FJointEditorToolkit::PasteNodesHere(const FVector2D& Location)
 				AttachTargetNode->AddSubNode(CastedPastedNode);
 
 				// Remove the Paste Node from the graph.
+				CastedGraph->RemoveNode(CastedPastedNode);
+			}
+		}
+	}else
+	{
+		for (UEdGraphNode* InEdGraphNode : PastedNodes)
+		{
+			if (InEdGraphNode == nullptr) continue;
+		
+			if (UJointEdGraphNode_Fragment* CastedPastedNode = Cast<UJointEdGraphNode_Fragment>(InEdGraphNode))
+			{
 				CastedGraph->RemoveNode(CastedPastedNode);
 			}
 		}

--- a/Source/JointEditor/Private/Node/JointEdGraphNode.cpp
+++ b/Source/JointEditor/Private/Node/JointEdGraphNode.cpp
@@ -987,6 +987,8 @@ void UJointEdGraphNode::PostCopyNode()
 
 void UJointEdGraphNode::PostPasteNode()
 {
+	ResetPinDataGuid();
+	
 	//Set this node's outer to the graph or the parent node, to prevent the issues during the copy-paste action.
 	RestoreOuterChainFromCopy();
 	
@@ -1434,6 +1436,22 @@ void UJointEdGraphNode::UpdateSubNodeChain()
 bool UJointEdGraphNode::IsSubNode() const
 {
 	return ParentNode == nullptr ? false : ParentNode->IsValidLowLevel();
+}
+
+TArray<UJointEdGraphNode*> UJointEdGraphNode::GetAllParentNodesInHierarchy() const
+{
+	TArray<UJointEdGraphNode*> ParentNodes;
+
+	UJointEdGraphNode* CurrentParentNode = ParentNode.Get();
+
+	while (CurrentParentNode != nullptr && CurrentParentNode->IsValidLowLevel())
+	{
+		ParentNodes.Add(CurrentParentNode);
+
+		CurrentParentNode = CurrentParentNode->ParentNode.Get();
+	}
+
+	return ParentNodes;
 }
 
 

--- a/Source/JointEditor/Public/Node/JointEdGraphNode.h
+++ b/Source/JointEditor/Public/Node/JointEdGraphNode.h
@@ -495,6 +495,9 @@ public:
 	
 	//Check if node is sub node. It will return if the parent node instance is valid.
 	virtual bool IsSubNode() const;
+	
+	//Grab all the parent nodes in the hierarchy.
+	virtual TArray<UJointEdGraphNode*> GetAllParentNodesInHierarchy() const;
 
 	//Grab all the sub nodes in the hierarchy.
 	virtual TArray<UJointEdGraphNode*> GetAllSubNodesInHierarchy() const;


### PR DESCRIPTION
Fixed an issue where JointMovieTrack incorrectly consumed input or behavior from other editors.

Fixed an issue where copied fragments did not preserve pin data correctly, causing pins to be displayed incorrectly in the editor.

Fixed an issue where copy-pasting a fragment without selecting any base nodes could leave invalid graph nodes in the graph.

Fixed an assertion triggered during paste when attempting to copy sub-nodes that were already implicitly included as children of selected nodes.