### PR TITLE
Joint 2.13.2

### DIFF
--- a/Source/JointEditor/Private/Editor/Slate/EditorWidget/SJointNodePalette.cpp
+++ b/Source/JointEditor/Private/Editor/Slate/EditorWidget/SJointNodePalette.cpp
@@ -71,15 +71,19 @@ void SJointNodePalette::OnActionSelected(const TArray<TSharedPtr<FEdGraphSchemaA
 			
 			// get current center location of the graph view to spawn the node preset at
 			
-			FJointSlateVector2D ViewLocation;
+			FVector2D ViewLocation;
 			float ZoomAmount;
-			FJointSlateVector2D ViewSize = ToolKitPtr.Pin()->GetFocusedGraphEditor()->GetDesiredSize();
+			FVector2D ViewSize = ToolKitPtr.Pin()->GetFocusedGraphEditor()->GetDesiredSize();
 			
 			ToolKitPtr.Pin()->GetFocusedGraphEditor()->GetViewLocation(ViewLocation, ZoomAmount);
 			
 			float ZoomOffsetMul = 1 / ZoomAmount;
 			ViewLocation = ViewLocation + ViewSize * ZoomOffsetMul * 2.5;
+#if UE_VERSION_OLDER_THAN(5,6,0)
 			NodePresetAction->PerformAction(ToolKitPtr.Pin()->GetFocusedJointGraph(), nullptr, ViewLocation);
+#else
+			NodePresetAction->PerformAction(ToolKitPtr.Pin()->GetFocusedJointGraph(), nullptr, FVector2f(ViewLocation));
+#endif
 		}
 		else
 		{

--- a/Source/JointEditor/Private/Editor/Toolkit/JointEdGraphNodesCustomization.cpp
+++ b/Source/JointEditor/Private/Editor/Toolkit/JointEdGraphNodesCustomization.cpp
@@ -59,7 +59,7 @@
 
 #include "Misc/EngineVersionComparison.h"
 
-#if UE_VERSION_OLDER_THAN(5, 4, 0)
+#if UE_VERSION_OLDER_THAN(5, 3, 0)
 #include "PropertyEditor/Private/PropertyNode.h"
 #else
 

--- a/Source/JointEditor/Public/Asset/Thumbnail/JointManagerThumbnailRenderer.h
+++ b/Source/JointEditor/Public/Asset/Thumbnail/JointManagerThumbnailRenderer.h
@@ -48,7 +48,7 @@ public:
 private:
 	
 	TSharedPtr<SJointGraphPreviewer> GraphPreviewer;
-	UTextureRenderTarget2D* ThumbnailRenderTarget = nullptr;
+	TObjectPtr<UTextureRenderTarget2D> ThumbnailRenderTarget = nullptr;
 	
 private:
 	

--- a/Source/JointEditor/Public/Editor/Slate/EditorWidget/JointGraphEditor.h
+++ b/Source/JointEditor/Public/Editor/Slate/EditorWidget/JointGraphEditor.h
@@ -108,7 +108,7 @@ public:
 	 * @param OutLocation		Will have the current view location
 	 * @param OutZoomAmount		Will have the current zoom amount
 	 */
-	virtual void GetViewLocation(FJointSlateVector2D& OutLocation, float& OutZoomAmount) override
+	virtual void GetViewLocation(FVector2D& OutLocation, float& OutZoomAmount) override
 	{
 		if (Implementation.IsValid())
 		{


### PR DESCRIPTION
Replace legacy FJointSlateVector2D with FVector2D in JointGraphEditor and SJointNodePalette, and add an UE_VERSION_OLDER_THAN(5,6,0) guard to call PerformAction with FVector2f on newer engines. Change the version guard in JointEdGraphNodesCustomization from 5.4.0 to 5.3.0. Convert ThumbnailRenderTarget raw pointer to TObjectPtr for proper UObject pointer handling. These changes improve compatibility with newer Unreal Engine API signatures and pointer safety. Modified files: SJointNodePalette.cpp, JointEdGraphNodesCustomization.cpp, JointManagerThumbnailRenderer.h, JointGraphEditor.h.